### PR TITLE
Version 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+
+feiertagsmatrix.xlsx

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Simply download the package or install it from npm with `npm install feiertage`.
 ```js
 var feiertage = require('feiertage');
 
-// non-business days for the current year
-// returns a Date object
-// full list of all non-business days
+// full list of all functions to retrieve the date for a specific non-business day of the current year
 feiertage.Neujahr();
 feiertage.HeiligeDreiKoenige();
 feiertage.Karfreitag();
@@ -32,20 +30,48 @@ feiertage.ErsterWeihnachtsfeiertag();
 feiertage.ZweiterWeihnachtsfeiertag();
 feiertage.Silvester();
 
-// non-business days for the current year as an object
-// e.g. list.Neujahr.label
-//      list.Neujahr.date
+// every function accepts a year as a parameter
+feiertage.Neujahr(2019);
+feiertage.HeiligeDreiKoenige(2020);
+...
+
+// non-business days for the current year as a list of objects
+// every objects has the properties id, label, date
 feiertage.asList();
 
-// non-business days for a specific year as an object
+// non-business days for a given year as a list of objects
+feiertage.asList(2020);
 feiertage.asList(2021);
 
-// sets the year once for every subsequent calculation
-feiertage.setYear(2019);
-feiertage.Neujahr();
-feiertage.HeiligeDreiKoenige();
-
-// explicitly set the year for every calculation
-feiertage.Neujahr(2020);
-feiertage.HeiligeDreiKoenige(2020);
+// asList also accepts a german state code, like BY, BE, SH or TH, so it returns only non-business days valid for these german states
+feiertage.asList(2020, 'BY');
+feiertage.asList(2021, 'BE');
 ```
+
+A list of the supported german state codes. DE exists to specify that all known non-business days should be included.
+
+* DE = Deutschland
+* BW = Baden-Württemberg
+* BY = Bayern
+* BE = Berlin
+* BB = Brandenburg
+* HB = Bremen
+* HH = Hamburg
+* HE = Hessen
+* NI = Niedersachsen
+* MV = Mecklenburg-Vorpommern
+* NW = Nordrhein-Westfalen
+* RP = Rheinland-Pfalz
+* SL = Saarland
+* SN = Sachsen
+* ST = Sachsen-Anhalt
+* SH = Schleswig-Holstein
+* TH = Thüringen
+
+## Changelog
+
+### 1.1.0
+
+* setYear() was removed from the API
+* asList() now accepts a state code as second parameter, e.g. BY, BE, SH or TH
+* asList() now returns a list of objects instead of an object

--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
 var FeiertageJS = function() {};
 
 FeiertageJS.prototype.year = new Date().getFullYear();
+FeiertageJS.prototype.state = 'DE';
 
 FeiertageJS.prototype.createDate = function(day, month, year) {
   year = typeof year !== 'undefined' ? year : this.year;
   return new Date(Date.UTC(year, month - 1, day));
 };
 
-FeiertageJS.prototype.GaussianEaster = function(year) {
-  year = typeof year !== 'undefined' ? year : this.year;
+FeiertageJS.prototype.gaussianEaster = function(year, modifier) {
+  modifier = typeof modifier !== 'undefined' ? modifier : 0;
   var a = year % 19,
     b = year % 4,
     c = year % 7,
@@ -20,150 +21,557 @@ FeiertageJS.prototype.GaussianEaster = function(year) {
     N = (4 + k - q) % 7,
     e = (2 * b + 4 * c + 6 * d + N) % 7,
     Ostern = 22 + d + e;
-  return [Ostern, 3];
+  return [Ostern + modifier, 3];
 };
 
-FeiertageJS.prototype.setYear = function(year) {
-  if (typeof year == 'number' && year > 1583 && year < 8202) {
-    this.year = year;
-  }
-};
+FeiertageJS.prototype.States = [
+  'DE', // Deutschland
+  'BW', // Baden-Württemberg
+  'BY', // Bayern
+  'BE', // Berlin
+  'BB', // Brandenburg
+  'HB', // Bremen
+  'HH', // Hamburg
+  'HE', // Hessen
+  'NI', // Niedersachsen
+  'MV', // Mecklenburg-Vorpommern
+  'NW', // Nordrhein-Westfalen
+  'RP', // Rheinland-Pfalz
+  'SL', // Saarland
+  'SN', // Sachsen
+  'ST', // Sachsen-Anhalt
+  'SH', // Schleswig-Holstein
+  'TH' // Thüringen
+];
 
-FeiertageJS.prototype.asList = function(year) {
+FeiertageJS.prototype.getDate = function(holidayId, year) {
   year = typeof year !== 'undefined' ? year : this.year;
-  return {
-    Neujahr: {
-      label: 'Neujahr',
-      date: this.Neujahr(year)
+
+  var theHoliday = {};
+
+  FeiertageJS.prototype.Holidays.forEach(function(holiday) {
+    if (holiday.id == holidayId) {
+      theHoliday = holiday;
+    }
+  });
+
+  return theHoliday.calc(year);
+};
+
+FeiertageJS.prototype.Holidays = [
+  {
+    id: 'neujahr',
+    type: 'static',
+    label: 'Neujahr',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(1, 1, year);
     },
-    HeiligeDreiKoenige: {
-      label: 'Hl. Drei Könige',
-      date: this.HeiligeDreiKoenige(year)
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'heiligedreikoenige',
+    type: 'static',
+    label: 'Hl. Drei Könige',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(6, 1, year);
     },
-    Karfreitag: { label: 'Karfreitag', date: this.Karfreitag(year) },
-    Ostersonntag: { label: 'Ostersonntag', date: this.Ostersonntag(year) },
-    Ostermontag: { label: 'Ostermontag', date: this.Ostermontag(year) },
-    TagDerArbeit: { label: 'Tag der Arbeit', date: this.TagDerArbeit(year) },
-    ChristiHimmelfahrt: {
-      label: 'Christi Himmelfahrt',
-      date: this.ChristiHimmelfahrt(year)
+    valid: ['DE', 'BW', 'BY', 'ST']
+  },
+  {
+    id: 'karfreitag',
+    type: 'variable',
+    label: 'Karfreitag',
+    calc: function(year) {
+      var date = FeiertageJS.prototype.gaussianEaster(year, -2);
+      return FeiertageJS.prototype.createDate(date[0], date[1], year);
     },
-    Pfingstsonntag: {
-      label: 'Pfingstsonntag',
-      date: this.Pfingstsonntag(year)
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'ostersonntag',
+    type: 'variable',
+    label: 'Ostersonntag',
+    calc: function(year) {
+      var date = FeiertageJS.prototype.gaussianEaster(year);
+      return FeiertageJS.prototype.createDate(date[0], date[1], year);
     },
-    Pfingstmontag: { label: 'Pfingstmontag', date: this.Pfingstmontag(year) },
-    Fronleichnam: { label: 'Fronleichnam', date: this.Fronleichnam(year) },
-    MariaHimmelfahrt: {
-      label: 'Mariä Himmelfahrt',
-      date: this.MariaHimmelfahrt(year)
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'ostermontag',
+    type: 'variable',
+    label: 'Ostermontag',
+    calc: function(year) {
+      var date = FeiertageJS.prototype.gaussianEaster(year, 1);
+      return FeiertageJS.prototype.createDate(date[0], date[1], year);
     },
-    TagDerDeutschenEinheit: {
-      label: 'Tag der dt. Einheit',
-      date: this.TagDerDeutschenEinheit(year)
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'tagderarbeit',
+    type: 'static',
+    label: 'Tag der Arbeit',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(1, 5, year);
     },
-    Reformationstag: {
-      label: 'Reformationstag',
-      date: this.Reformationstag(year)
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'christihimmelfahrt',
+    type: 'variable',
+    label: 'Christi Himmelfahrt',
+    calc: function(year) {
+      var date = FeiertageJS.prototype.gaussianEaster(year, 39);
+      return FeiertageJS.prototype.createDate(date[0], date[1], year);
     },
-    Allerheiligen: { label: 'Allerheiligen', date: this.Allerheiligen(year) },
-    Heiligabend: { label: 'Heiligabend', date: this.Heiligabend(year) },
-    ErsterWeihnachtsfeiertag: {
-      label: '1. Weihnachtsfeiertag',
-      date: this.ErsterWeihnachtsfeiertag(year)
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'pfingstsonntag',
+    type: 'variable',
+    label: 'Pfingstsonntag',
+    calc: function(year) {
+      var date = FeiertageJS.prototype.gaussianEaster(year, 49);
+      return FeiertageJS.prototype.createDate(date[0], date[1], year);
     },
-    ZweiterWeihnachtsfeiertag: {
-      label: '2. Weihnachtsfeiertag',
-      date: this.ZweiterWeihnachtsfeiertag(year)
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'pfingstmontag',
+    type: 'variable',
+    label: 'Pfingstmontag',
+    calc: function(year) {
+      var date = FeiertageJS.prototype.gaussianEaster(year, 50);
+      return FeiertageJS.prototype.createDate(date[0], date[1], year);
     },
-    Silvester: { label: 'Silvester', date: this.Silvester(year) }
-  };
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'fronleichnam',
+    type: 'variable',
+    label: 'Fronleichnam',
+    calc: function(year) {
+      var date = FeiertageJS.prototype.gaussianEaster(year, 60);
+      return FeiertageJS.prototype.createDate(date[0], date[1], year);
+    },
+    valid: ['DE', 'BW', 'BY', 'HE', 'NW', 'RP', 'SL', 'TH']
+  },
+  {
+    id: 'mariahimmelfahrt',
+    type: 'static',
+    label: 'Mariä Himmelfahrt',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(15, 8, year);
+    },
+    valid: ['DE', 'BY', 'SL']
+  },
+  {
+    id: 'tagderdeutscheneinheit',
+    type: 'static',
+    label: 'Tag der dt. Einheit',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(3, 10, year);
+    },
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'reformationstag',
+    type: 'static',
+    label: 'Reformationstag',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(31, 10, year);
+    },
+    valid: ['DE', 'BB', 'MV', 'SN', 'ST', 'TH']
+  },
+  {
+    id: 'allerheiligen',
+    type: 'static',
+    label: 'Allerheiligen',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(1, 11, year);
+    },
+    valid: ['DE', 'BW', 'BY', 'NW', 'RP', 'SL']
+  },
+  {
+    id: 'bußundbettag',
+    type: 'variable',
+    label: 'Buß- und Bettag',
+    calc: function(year) {
+      return new Date(
+        Date.UTC(year, 11, 25 - new Date(Date.UTC(year, 11, 25)).getDay() - 32)
+      );
+    },
+    valid: ['DE', 'SN']
+  },
+  {
+    id: 'heiligabend',
+    type: 'static',
+    label: 'Heiligabend',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(24, 12, year);
+    },
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'ersterweihnachtsfeiertag',
+    type: 'static',
+    label: '1. Weihnachtsfeiertag',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(25, 12, year);
+    },
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'zweiterweihnachtsfeiertag',
+    type: 'static',
+    label: '2. Weihnachtsfeiertag',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(26, 12, year);
+    },
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  },
+  {
+    id: 'silvester',
+    type: 'static',
+    label: 'Silvester',
+    calc: function(year) {
+      return FeiertageJS.prototype.createDate(31, 12, year);
+    },
+    valid: [
+      'DE',
+      'BW',
+      'BY',
+      'BE',
+      'BB',
+      'HB',
+      'HH',
+      'HE',
+      'MV',
+      'NI',
+      'NW',
+      'RP',
+      'SL',
+      'SN',
+      'ST',
+      'SH',
+      'TH'
+    ]
+  }
+];
+
+FeiertageJS.prototype.asList = function(year, state) {
+  year = typeof year !== 'undefined' ? year : this.year;
+  state =
+    typeof state !== 'undefined' &&
+    FeiertageJS.prototype.States.indexOf(state.toUpperCase()) > -1
+      ? state.toUpperCase()
+      : this.state;
+
+  var dates = [];
+
+  this.Holidays.forEach(function(holiday) {
+    if (holiday.valid.indexOf(state) > -1) {
+      dates.push({
+        id: holiday.id,
+        label: holiday.label,
+        date: holiday.calc(year)
+      });
+    }
+  });
+
+  return dates;
 };
 
 FeiertageJS.prototype.Neujahr = function(year) {
-  return this.createDate(1, 1, year);
+  return FeiertageJS.prototype.getDate('neujahr', year);
 };
 
 FeiertageJS.prototype.HeiligeDreiKoenige = function(year) {
-  return this.createDate(6, 1, year);
+  return FeiertageJS.prototype.getDate('heiligedreikoenige', year);
 };
 
 FeiertageJS.prototype.Karfreitag = function(year) {
-  var easter = this.GaussianEaster(year);
-  return this.createDate(easter[0] - 2, easter[1], year);
+  return FeiertageJS.prototype.getDate('karfreitag', year);
 };
 
 FeiertageJS.prototype.Ostersonntag = function(year) {
-  var easter = this.GaussianEaster(year);
-  return this.createDate(easter[0], easter[1], year);
+  return FeiertageJS.prototype.getDate('ostersonntag', year);
 };
 
 FeiertageJS.prototype.Ostermontag = function(year) {
-  var easter = this.GaussianEaster(year);
-  return this.createDate(easter[0] + 1, easter[1], year);
+  return FeiertageJS.prototype.getDate('ostermontag', year);
 };
 
 FeiertageJS.prototype.TagDerArbeit = function(year) {
-  return this.createDate(1, 5, year);
+  return FeiertageJS.prototype.getDate('tagderarbeit', year);
 };
 
 FeiertageJS.prototype.ChristiHimmelfahrt = function(year) {
-  var easter = this.GaussianEaster(year);
-  return this.createDate(easter[0] + 39, easter[1], year);
+  return FeiertageJS.prototype.getDate('christihimmelfahrt', year);
 };
 
 FeiertageJS.prototype.Pfingstsonntag = function(year) {
-  var easter = this.GaussianEaster(year);
-  return this.createDate(easter[0] + 49, easter[1], year);
+  return FeiertageJS.prototype.getDate('pfingstsonntag', year);
 };
 
 FeiertageJS.prototype.Pfingstmontag = function(year) {
-  var easter = this.GaussianEaster(year);
-  return this.createDate(easter[0] + 50, easter[1], year);
+  return FeiertageJS.prototype.getDate('pfingstmontag', year);
 };
 
 FeiertageJS.prototype.Fronleichnam = function(year) {
-  var easter = this.GaussianEaster(year);
-  return this.createDate(easter[0] + 60, easter[1], year);
+  return FeiertageJS.prototype.getDate('fronleichnam', year);
 };
 
 FeiertageJS.prototype.MariaHimmelfahrt = function(year) {
-  return this.createDate(15, 8, year);
+  return FeiertageJS.prototype.getDate('mariahimmelfahrt', year);
 };
 
 FeiertageJS.prototype.TagDerDeutschenEinheit = function(year) {
-  return this.createDate(3, 10, year);
+  return FeiertageJS.prototype.getDate('tagderdeutscheneinheit', year);
 };
 
 FeiertageJS.prototype.Reformationstag = function(year) {
-  return this.createDate(31, 10, year);
+  return FeiertageJS.prototype.getDate('reformationstag', year);
 };
 
 FeiertageJS.prototype.Allerheiligen = function(year) {
-  return this.createDate(1, 11, year);
+  return FeiertageJS.prototype.getDate('allerheiligen', year);
 };
 
 FeiertageJS.prototype.BußUndBettag = function(year) {
-  year = typeof year !== 'undefined' ? year : this.year;
-  return new Date(
-    Date.UTC(year, 11, 25 - new Date(Date.UTC(year, 11, 25)).getDay() - 32)
-  );
+  return FeiertageJS.prototype.getDate('bußundbettag', year);
 };
 
 FeiertageJS.prototype.Heiligabend = function(year) {
-  return this.createDate(24, 12, year);
+  return FeiertageJS.prototype.getDate('heiligabend', year);
 };
 
 FeiertageJS.prototype.ErsterWeihnachtsfeiertag = function(year) {
-  return this.createDate(25, 12, year);
+  return FeiertageJS.prototype.getDate('ersterweihnachtsfeiertag', year);
 };
 
 FeiertageJS.prototype.ZweiterWeihnachtsfeiertag = function(year) {
-  return this.createDate(26, 12, year);
+  return FeiertageJS.prototype.getDate('zweiterweihnachtsfeiertag', year);
 };
 
 FeiertageJS.prototype.Silvester = function(year) {
-  return this.createDate(31, 12, year);
+  return FeiertageJS.prototype.getDate('silvester', year);
 };
 
 module.exports = new FeiertageJS();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feiertage",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description":
     "Tiny, simple and pure module to calculate the german non-business days.",
   "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -10,34 +10,33 @@ testdata.push({
   validation: {
     Neujahr: toDate(2018, 1, 1),
     HeiligeDreiKoenige: toDate(2018, 1, 6),
-    Ostersonntag: toDate(2018, 4, 1),
-    Pfingstsonntag: toDate(2018, 5, 20),
+    Ostermontag: toDate(2018, 4, 2),
+    Pfingstmontag: toDate(2018, 5, 21),
     BußUndBettag: toDate(2018, 11, 21)
   },
   test: {
     Neujahr: feiertage.Neujahr(),
     HeiligeDreiKoenige: feiertage.HeiligeDreiKoenige(),
-    Ostersonntag: feiertage.Ostersonntag(),
-    Pfingstsonntag: feiertage.Pfingstsonntag(),
+    Ostermontag: feiertage.Ostermontag(),
+    Pfingstmontag: feiertage.Pfingstmontag(),
     BußUndBettag: feiertage.BußUndBettag()
   }
 });
 
-feiertage.setYear(2019);
 testdata.push({
   validation: {
     Neujahr: toDate(2019, 1, 1),
     HeiligeDreiKoenige: toDate(2019, 1, 6),
-    Ostersonntag: toDate(2019, 4, 21),
-    Pfingstsonntag: toDate(2019, 6, 9),
+    Ostermontag: toDate(2019, 4, 22),
+    Pfingstmontag: toDate(2019, 6, 10),
     BußUndBettag: toDate(2019, 11, 20)
   },
   test: {
-    Neujahr: feiertage.Neujahr(),
-    HeiligeDreiKoenige: feiertage.HeiligeDreiKoenige(),
-    Ostersonntag: feiertage.Ostersonntag(),
-    Pfingstsonntag: feiertage.Pfingstsonntag(),
-    BußUndBettag: feiertage.BußUndBettag()
+    Neujahr: feiertage.Neujahr(2019),
+    HeiligeDreiKoenige: feiertage.HeiligeDreiKoenige(2019),
+    Ostermontag: feiertage.Ostermontag(2019),
+    Pfingstmontag: feiertage.Pfingstmontag(2019),
+    BußUndBettag: feiertage.BußUndBettag(2019)
   }
 });
 
@@ -45,15 +44,15 @@ testdata.push({
   validation: {
     Neujahr: toDate(2020, 1, 1),
     HeiligeDreiKoenige: toDate(2020, 1, 6),
-    Ostersonntag: toDate(2020, 4, 12),
-    Pfingstsonntag: toDate(2020, 5, 31),
+    Ostermontag: toDate(2020, 4, 13),
+    Pfingstmontag: toDate(2020, 6, 1),
     BußUndBettag: toDate(2020, 11, 18)
   },
   test: {
     Neujahr: feiertage.Neujahr(2020),
     HeiligeDreiKoenige: feiertage.HeiligeDreiKoenige(2020),
-    Ostersonntag: feiertage.Ostersonntag(2020),
-    Pfingstsonntag: feiertage.Pfingstsonntag(2020),
+    Ostermontag: feiertage.Ostermontag(2020),
+    Pfingstmontag: feiertage.Pfingstmontag(2020),
     BußUndBettag: feiertage.BußUndBettag(2020)
   }
 });
@@ -62,8 +61,8 @@ testdata.forEach(function(dataset) {
   var keys = [
     'Neujahr',
     'HeiligeDreiKoenige',
-    'Ostersonntag',
-    'Pfingstsonntag',
+    'Ostermontag',
+    'Pfingstmontag',
     'BußUndBettag'
   ];
 
@@ -79,4 +78,9 @@ testdata.forEach(function(dataset) {
   console.log('');
 });
 
-console.log(JSON.stringify(feiertage.asList(2021)));
+var feiertageAll = feiertage.asList(2021);
+console.log('Feiertage 2021 (deutschlandweit): ' + feiertageAll.length);
+var feiertageBY = feiertage.asList(2021, 'BY');
+console.log('Feiertage 2021 (Bayern): ' + feiertageBY.length);
+var feiertageBE = feiertage.asList(2021, 'BE');
+console.log('Feiertage 2021 (Berlin): ' + feiertageBE.length);


### PR DESCRIPTION
* `setYear()` was removed from the API
* `asList()` now accepts a state code as second parameter, e.g. BY, BE, SH or TH
* `asList()` now returns a list of objects instead of an object