### PR TITLE
Added Special State Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Tiny, simple and pure module to calculate the german non-business days.
 
+[![NPM](https://nodei.co/npm/feiertage.png)](https://nodei.co/npm/feiertage/)
+
 ## How To Use
 
 Simply download the package or install it from npm with `npm install feiertage`.
@@ -51,27 +53,37 @@ feiertage.asList(2021, 'BE');
 feiertage.asListOfWorkdays(2016, 'BY');
 ```
 
-A list of the supported german state codes. DE exists to specify that all known non-business days should be included.
+A list of the supported german state codes. There are five additional codes to specify special regulations for Friedensfest, Mariä Himmelfahrt and Fronleichnam. The code DE summarizes all german non-business days.
 
-* DE = Deutschland
-* BW = Baden-Württemberg
-* BY = Bayern
-* BE = Berlin
-* BB = Brandenburg
-* HB = Bremen
-* HH = Hamburg
-* HE = Hessen
-* NI = Niedersachsen
-* MV = Mecklenburg-Vorpommern
-* NW = Nordrhein-Westfalen
-* RP = Rheinland-Pfalz
-* SL = Saarland
-* SN = Sachsen
-* ST = Sachsen-Anhalt
-* SH = Schleswig-Holstein
-* TH = Thüringen
+| Code  | Description                                                                            |
+| ----- | -------------------------------------------------------------------------------------- |
+| DE    | Deutschland (all known non-business days)                                              |
+| BW    | Baden-Württemberg                                                                      |
+| BY    | Bayern                                                                                 |
+| BE    | Berlin                                                                                 |
+| BB    | Brandenburg                                                                            |
+| HB    | Bremen                                                                                 |
+| HH    | Hamburg                                                                                |
+| HE    | Hessen                                                                                 |
+| NI    | Niedersachsen                                                                          |
+| MV    | Mecklenburg-Vorpommern                                                                 |
+| NW    | Nordrhein-Westfalen                                                                    |
+| RP    | Rheinland-Pfalz                                                                        |
+| SL    | Saarland                                                                               |
+| SN    | Sachsen                                                                                |
+| ST    | Sachsen-Anhalt                                                                         |
+| SH    | Schleswig-Holstein                                                                     |
+| TH    | Thüringen                                                                              |
+| BY-FF | Bayern, Friedensfest, Augsburg only                                                    |
+| BY-MH | Bayern, Mariä Himmelfahrt, predominantly catholic population                           |
+| SN-FL | Sachsen, Fronleichnam, some communities in Bautzen                                     |
+| TH-FL | Thüringen, Fronleichnam, some communities in Eichsfeld, Unstrut-Hainich, Wartburgkreis |
 
 ## Changelog
+
+### 1.2.0
+
+* Added special state codes for `BY-FF`, `BY-MH`, `SN-FL` and `TH-FL` covering the special rules for non-business days, that are only valid in some communities, like Friedensfest, Mariä-Himmelfahrt and Fronleichnam.
 
 ### 1.1.2
 

--- a/index.js
+++ b/index.js
@@ -78,7 +78,11 @@ FeiertageJS.prototype.States = [
   'SN', // Sachsen
   'ST', // Sachsen-Anhalt
   'SH', // Schleswig-Holstein
-  'TH' // Thüringen
+  'TH', // Thüringen
+  'BY-FF', // Bayern, Friedensfest, Stadt Augsburg
+  'BY-MH', // Bayern, überwiegend katholische Bevölkerung
+  'SN-FL', // Sachsen, Bautzen
+  'TH-FL' // Thüringen, Eichsfeld, Unstrut-Hainich, Wartburgkreis
 ];
 
 /**

--- a/model.js
+++ b/model.js
@@ -3,6 +3,7 @@ module.exports = [
     id: 'neujahr',
     type: 'full',
     label: 'Neujahr',
+    short: 'NJ',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 0, 1));
     },
@@ -30,6 +31,7 @@ module.exports = [
     id: 'heiligedreikoenige',
     type: 'full',
     label: 'Heilige Drei Könige',
+    short: 'DK',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 0, 6));
     },
@@ -39,6 +41,7 @@ module.exports = [
     id: 'karfreitag',
     type: 'full',
     label: 'Karfreitag',
+    short: 'KF',
     calc: function(year, easter_date) {
       return new Date(
         Date.UTC(year, easter_date.month - 1, easter_date.day - 2)
@@ -68,6 +71,7 @@ module.exports = [
     id: 'ostersonntag',
     type: 'full',
     label: 'Ostersonntag',
+    short: 'OS',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, easter_date.month - 1, easter_date.day));
     },
@@ -77,6 +81,7 @@ module.exports = [
     id: 'ostermontag',
     type: 'full',
     label: 'Ostermontag',
+    short: 'OM',
     calc: function(year, easter_date) {
       return new Date(
         Date.UTC(year, easter_date.month - 1, easter_date.day + 1)
@@ -106,6 +111,7 @@ module.exports = [
     id: 'tagderarbeit',
     type: 'full',
     label: 'Tag der Arbeit',
+    short: 'TA',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 4, 1));
     },
@@ -133,6 +139,7 @@ module.exports = [
     id: 'christihimmelfahrt',
     type: 'full',
     label: 'Christi Himmelfahrt',
+    short: 'CH',
     calc: function(year, easter_date) {
       return new Date(
         Date.UTC(year, easter_date.month - 1, easter_date.day + 39)
@@ -162,6 +169,7 @@ module.exports = [
     id: 'pfingstsonntag',
     type: 'full',
     label: 'Pfingstsonntag',
+    short: 'PS',
     calc: function(year, easter_date) {
       return new Date(
         Date.UTC(year, easter_date.month - 1, easter_date.day + 49)
@@ -173,6 +181,7 @@ module.exports = [
     id: 'pfingstmontag',
     type: 'full',
     label: 'Pfingstmontag',
+    short: 'PM',
     calc: function(year, easter_date) {
       return new Date(
         Date.UTC(year, easter_date.month - 1, easter_date.day + 50)
@@ -202,12 +211,13 @@ module.exports = [
     id: 'fronleichnam',
     type: 'full',
     label: 'Fronleichnam',
+    short: 'FL',
     calc: function(year, easter_date) {
       return new Date(
         Date.UTC(year, easter_date.month - 1, easter_date.day + 60)
       );
     },
-    valid: ['DE', 'BW', 'BY', 'HE', 'NW', 'RP', 'SL'],
+    valid: ['DE', 'BW', 'BY', 'HE', 'NW', 'RP', 'SL', 'SN-FL', 'TH-FL'],
     comment:
       'Eingeschränkt gültig in SN und TH, siehe [](https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland).'
   },
@@ -215,10 +225,11 @@ module.exports = [
     id: 'augsburgerfriedensfest',
     type: 'full',
     label: 'Augsburger Hohes Friedensfest',
+    short: 'FF',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 7, 8));
     },
-    valid: [],
+    valid: ['BY-FF'],
     comment:
       'Nur im Augsburger Stadtgebiet gültig, nicht jedoch im angrenzenden Umland.'
   },
@@ -226,15 +237,17 @@ module.exports = [
     id: 'mariahimmelfahrt',
     type: 'full',
     label: 'Mariä Himmelfahrt',
+    short: 'MH',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 7, 15));
     },
-    valid: ['DE', 'BY', 'SL']
+    valid: ['DE', 'BY-MH', 'BY-FF', 'SL']
   },
   {
     id: 'tagderdeutscheneinheit',
     type: 'full',
     label: 'Tag der dt. Einheit',
+    short: 'EH',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 9, 3));
     },
@@ -262,6 +275,7 @@ module.exports = [
     id: 'reformationstag',
     type: 'full',
     label: 'Reformationstag',
+    short: 'RF',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 9, 31));
     },
@@ -292,6 +306,7 @@ module.exports = [
     id: 'allerheiligen',
     type: 'full',
     label: 'Allerheiligen',
+    short: 'AH',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 10, 1));
     },
@@ -301,6 +316,7 @@ module.exports = [
     id: 'bußundbettag',
     type: 'full',
     label: 'Buß- und Bettag',
+    short: 'BB',
     calc: function(year, easter_date) {
       return new Date(
         Date.UTC(year, 11, 25 - new Date(Date.UTC(year, 11, 25)).getDay() - 32)
@@ -312,6 +328,7 @@ module.exports = [
     id: 'heiligabend',
     type: 'half',
     label: 'Heiligabend',
+    short: 'HA',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 11, 24));
     },
@@ -339,6 +356,7 @@ module.exports = [
     id: 'ersterweihnachtsfeiertag',
     type: 'full',
     label: '1. Weihnachtsfeiertag',
+    short: 'EW',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 11, 25));
     },
@@ -366,6 +384,7 @@ module.exports = [
     id: 'zweiterweihnachtsfeiertag',
     type: 'full',
     label: '2. Weihnachtsfeiertag',
+    short: 'ZW',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 11, 26));
     },
@@ -393,6 +412,7 @@ module.exports = [
     id: 'silvester',
     type: 'half',
     label: 'Silvester',
+    short: 'SI',
     calc: function(year, easter_date) {
       return new Date(Date.UTC(year, 11, 31));
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feiertage",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description":
     "Tiny, simple and pure module to calculate the german non-business days.",
   "main": "index.js",


### PR DESCRIPTION
Added special state codes for `BY-FF`, `BY-MH`, `SN-FL` and `TH-FL`
covering the special rules for non-business days, that are only valid in
some communities, like Friedensfest, Mariä-Himmelfahrt and Fronleichnam.